### PR TITLE
Feat/renewal

### DIFF
--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -1,10 +1,12 @@
 use starknet::{ContractAddress, ClassHash};
-use naming::naming::main::Naming::Discount;
+use naming::naming::main::Naming::{Discount, DomainData};
 
 #[starknet::interface]
 trait INaming<TContractState> {
     // view
     fn resolve(self: @TContractState, domain: Span<felt252>, field: felt252) -> felt252;
+
+    fn domain_to_data(self: @TContractState, domain: Span<felt252>) -> DomainData;
 
     fn domain_to_id(self: @TContractState, domain: Span<felt252>) -> u128;
 

--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -24,6 +24,15 @@ trait INaming<TContractState> {
         metadata: felt252,
     );
 
+    fn renew(
+        ref self: TContractState,
+        domain: felt252,
+        days: u16,
+        sponsor: ContractAddress,
+        discount_id: felt252,
+        metadata: felt252,
+    );
+
     fn transfer_domain(ref self: TContractState, domain: Span<felt252>, target_id: u128);
 
     // admin

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -120,6 +120,7 @@ mod Naming {
         // This function allows to read the single felt target of any domain for a specific field
         // For example, it allows to find the Bitcoin address of Alice.stark by calling
         // naming.resolve(['alice'], 'bitcoin')
+        // Use it with caution in smartcontracts as it can call untrusted contracts
         fn resolve(self: @ContractState, domain: Span<felt252>, field: felt252) -> felt252 {
             let (resolver, parent_start) = self.domain_to_resolver(domain, 0);
             if (resolver != ContractAddressZeroable::zero()) {
@@ -136,6 +137,7 @@ mod Naming {
         // to be used as a parameter for other functions (for example if you want to send ERC20
         // to a .stark)
         fn domain_to_address(self: @ContractState, domain: Span<felt252>) -> ContractAddress {
+            // resolve must be performed first because it calls untrusted resolving contracts
             let resolve_result = self.resolve(domain, 'starknet');
             if resolve_result != 0 {
                 let addr: Option<ContractAddress> = resolve_result.try_into();
@@ -290,6 +292,7 @@ mod Naming {
                     )
                 );
 
+            // identity contract is trusted
             IIdentityDispatcher { contract_address: self.starknetid_contract.read() }
                 .set_verifier_data(current_domain_data.owner, 'name', 0, 0);
             IIdentityDispatcher { contract_address: self.starknetid_contract.read() }

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -149,6 +149,11 @@ mod Naming {
                 .owner_of(data.owner)
         }
 
+        // This returns the stored DomainData associated to this domain
+        fn domain_to_data(self: @ContractState, domain: Span<felt252>) -> DomainData {
+            self._domain_data.read(self.hash_domain(domain))
+        }
+
         // This returns the identity (StarknetID) owning the domain
         fn domain_to_id(self: @ContractState, domain: Span<felt252>) -> u128 {
             self._domain_data.read(self.hash_domain(domain)).owner

--- a/src/tests/naming/test_abuses.cairo
+++ b/src/tests/naming/test_abuses.cairo
@@ -75,13 +75,25 @@ fn test_buying_domain_twice() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     naming
         .buy(
-            id1, th0rgal, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0
+            id1,
+            th0rgal,
+            365,
+            ContractAddressZeroable::zero(),
+            ContractAddressZeroable::zero(),
+            0,
+            0
         );
 
     // buying again
     naming
         .buy(
-            id2, th0rgal, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0
+            id2,
+            th0rgal,
+            365,
+            ContractAddressZeroable::zero(),
+            ContractAddressZeroable::zero(),
+            0,
+            0
         );
 }
 
@@ -105,14 +117,22 @@ fn test_buying_twice_on_same_id() {
     let (_, price) = pricing.compute_buy_price(7, 365);
 
     // we allow the naming to take our money
-    eth.approve(naming.contract_address, price);
+    eth.approve(naming.contract_address, 2 * price);
 
     // we buy with no resolver, no sponsor, no discount and empty metadata
     naming
-        .buy(id, th0rgal, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0);
+        .buy(
+            id, th0rgal, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0
+        );
     naming
         .buy(
-            id, altdomain, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0
+            id,
+            altdomain,
+            365,
+            ContractAddressZeroable::zero(),
+            ContractAddressZeroable::zero(),
+            0,
+            0
         );
 }
 

--- a/src/tests/naming/test_usecases.cairo
+++ b/src/tests/naming/test_usecases.cairo
@@ -83,12 +83,16 @@ fn test_discounts() {
     set_contract_address(caller);
 
     // you pay only 50%
-    naming.set_discount('half', Discount{
-        domain_len_range: (1, 50),
-        days_range: (365, 365),
-        timestamp_range: (0, 0xffffffffffffffff),
-        amount: 50,
-    });
+    naming
+        .set_discount(
+            'half',
+            Discount {
+                domain_len_range: (1, 50),
+                days_range: (365, 365),
+                timestamp_range: (0, 0xffffffffffffffff),
+                amount: 50,
+            }
+        );
 
     let id: u128 = 1;
     let th0rgal: felt252 = 33133781693;
@@ -98,7 +102,7 @@ fn test_discounts() {
 
     // we check how much a domain costs
     let (_, price) = pricing.compute_buy_price(7, 365);
-    let to_pay = price/2;
+    let to_pay = price / 2;
 
     // we allow the naming to take our money
     eth.approve(naming.contract_address, to_pay);
@@ -106,6 +110,48 @@ fn test_discounts() {
     // we buy with no resolver, no sponsor, empty metadata but our HALF discount
     naming
         .buy(
-            id, th0rgal, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 'half', 0
+            id,
+            th0rgal,
+            365,
+            ContractAddressZeroable::zero(),
+            ContractAddressZeroable::zero(),
+            'half',
+            0
         );
+}
+
+
+#[test]
+#[available_gas(2000000000)]
+fn test_renewal() {
+    // setup
+    let (eth, pricing, identity, naming) = deploy();
+    let caller = contract_address_const::<0x123>();
+    set_contract_address(caller);
+    let id: u128 = 1;
+    let th0rgal: felt252 = 33133781693;
+
+    //we mint an id
+    identity.mint(id);
+
+    // we check how much a domain costs
+    let (_, price) = pricing.compute_buy_price(7, 365);
+
+    // we allow the naming to take our money
+    eth.approve(naming.contract_address, price);
+
+    // we buy with no resolver, no sponsor, no discount and empty metadata
+    naming
+        .buy(
+            id, th0rgal, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0
+        );
+
+    // we check how much a domain costs to renew
+    let (_, price) = pricing.compute_renew_price(7, 365);
+
+    // we allow the naming to take our money
+    eth.approve(naming.contract_address, price);
+
+    // we renew with no sponsor, no discount and empty metadata
+    naming.renew(th0rgal, 365, ContractAddressZeroable::zero(), 0, 0);
 }

--- a/src/tests/naming/test_usecases.cairo
+++ b/src/tests/naming/test_usecases.cairo
@@ -140,11 +140,15 @@ fn test_renewal() {
     // we allow the naming to take our money
     eth.approve(naming.contract_address, price);
 
+    let domain_span = array![th0rgal].span();
+    assert(naming.domain_to_data(domain_span).expiry == 0, 'non empty expiry');
+
     // we buy with no resolver, no sponsor, no discount and empty metadata
     naming
         .buy(
             id, th0rgal, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0
         );
+    assert(naming.domain_to_data(domain_span).expiry == 365 * 86400, 'invalid buy expiry');
 
     // we check how much a domain costs to renew
     let (_, price) = pricing.compute_renew_price(7, 365);
@@ -154,4 +158,5 @@ fn test_renewal() {
 
     // we renew with no sponsor, no discount and empty metadata
     naming.renew(th0rgal, 365, ContractAddressZeroable::zero(), 0, 0);
+    assert(naming.domain_to_data(domain_span).expiry == 2 * 365 * 86400, 'invalid renew expiry');
 }


### PR DESCRIPTION
This pull request introduces the missing `renew()` function to the naming contract. This renew function supports sponsor, discount and metadata, in the same fashion the `buy()` function does, we will update the Auto Renewal accordingly.
Here is what I added:
- the actual renew method implementation
- a test for renewing normally
- a test for renewing someone's domain
- tests for trying to abuse the renew function (too short or too long renewal)

I also added a few unrelated comments and minor refactors.