### PR TITLE
Wip2bis

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -18,3 +18,7 @@ casm = true
 
 # Emit Python-powered hints in order to run compiled CASM class with legacy Cairo VM.
 casm-add-pythonic-hints = true
+
+[lib]
+sierra = true 
+casm = false

--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -44,5 +44,9 @@ trait INaming<TContractState> {
 
     fn set_discount(ref self: TContractState, discount_id: felt252, discount: Discount);
 
+    fn set_pricing_contract(ref self: TContractState, pricing_contract: ContractAddress);
+
+    fn set_referral_contract(ref self: TContractState, referral_contract: ContractAddress);
+
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
 }

--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -37,6 +37,8 @@ trait INaming<TContractState> {
 
     fn transfer_domain(ref self: TContractState, domain: Span<felt252>, target_id: u128);
 
+    fn reset_subdomains(ref self: TContractState, domain: Span<felt252>);
+
     // admin
     fn set_admin(ref self: TContractState, new_admin: ContractAddress);
 

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -319,6 +319,16 @@ mod Naming {
             self.discounts.write(discount_id, discount);
         }
 
+        fn set_pricing_contract(ref self: ContractState, pricing_contract: ContractAddress) {
+            assert(get_caller_address() == self._admin_address.read(), 'you are not admin');
+            self._pricing_contract.write(pricing_contract);
+        }
+
+        fn set_referral_contract(ref self: ContractState, referral_contract: ContractAddress) {
+            assert(get_caller_address() == self._admin_address.read(), 'you are not admin');
+            self._referral_contract.write(referral_contract);
+        }
+
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             assert(get_caller_address() == self._admin_address.read(), 'you are not admin');
             // todo: use components

--- a/src/tests/naming/test_features.cairo
+++ b/src/tests/naming/test_features.cairo
@@ -32,10 +32,10 @@ fn test_subdomains() {
     let id2: u128 = 2;
     let th0rgal: felt252 = 33133781693;
     let hello: felt252 = 29811539;
-    let altdomain: felt252 = 57437602667574;
 
-    //we mint an id
+    //we mint the ids id
     identity.mint(id1);
+    identity.mint(id2);
 
     // we check how much a domain costs
     let (_, price) = pricing.compute_buy_price(7, 365);
@@ -60,10 +60,25 @@ fn test_subdomains() {
     // we transfer hello.th0rgal.stark to id2
     naming.transfer_domain(subdomain, id2);
 
+    assert(naming.domain_to_address(subdomain) == caller, 'wrong subdomain initial target');
+
     // and make sure the owner has been updated
     assert(naming.domain_to_id(subdomain) == id2, 'owner not updated correctly');
-}
 
+    let root_domain = array![th0rgal].span();
+
+    // we reset subdomains
+    naming.reset_subdomains(root_domain);
+
+    // ensure th0rgal still resolves
+    assert(naming.domain_to_id(root_domain) == id1, 'owner not updated correctly');
+
+    // ensure the subdomain was reset
+    assert(
+        naming.domain_to_address(subdomain) == ContractAddressZeroable::zero(),
+        'target not updated correctly'
+    );
+}
 
 #[test]
 #[available_gas(2000000000)]


### PR DESCRIPTION
This pull request adds **contracts setters** and the **reset_subdomains** feature. It makes the contract resolving slightly more complex.

I added a test to make sure it works. When reviewing I'ld like you to focus on how the reset_subdomains feature works. The idea is to allow to reset all subdomains of a domain to 0 without having to rewrite all of them (you pay o(1) felts instead of o(n)). It relies on a key system between domains and their children. Don't hesitate to ask if something isn't clear, I'll add comments according to your questions to make the auditing process simpler. 

What is left to do:
- refactoring the code (we will need some cairo updates to allow to move events and other stuff out of the main file)
- optimizing (some domain hashes are computed too many times, using #inline could help)
- check storage compatibility
- Relying on components for inheriting things like upgradability
- Handling events (not everything has been ported)
- Porting existing tests
- Increasing test coverage to cover more scenarii

