### PR TITLE
feature: reverse resolving

### DIFF
--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -39,6 +39,8 @@ trait INaming<TContractState> {
 
     fn reset_subdomains(ref self: TContractState, domain: Span<felt252>);
 
+    fn set_address_to_domain(ref self: TContractState, domain: Span<felt252>);
+
     // admin
     fn set_admin(ref self: TContractState, new_admin: ContractAddress);
 

--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -12,7 +12,7 @@ trait INaming<TContractState> {
 
     fn domain_to_address(self: @TContractState, domain: Span<felt252>) -> ContractAddress;
 
-    fn address_to_domain(self: @TContractState, address: ContractAddress) -> Array<felt252>;
+    fn address_to_domain(self: @TContractState, address: ContractAddress) -> Span<felt252>;
 
     // external
     fn buy(
@@ -40,6 +40,8 @@ trait INaming<TContractState> {
     fn reset_subdomains(ref self: TContractState, domain: Span<felt252>);
 
     fn set_address_to_domain(ref self: TContractState, domain: Span<felt252>);
+
+    fn reset_address_to_domain(ref self: TContractState);
 
     // admin
     fn set_admin(ref self: TContractState, new_admin: ContractAddress);

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -215,11 +215,11 @@ mod Naming {
         }
 
         // This function allows to find which domain to use to display an account
-        fn address_to_domain(self: @ContractState, address: ContractAddress) -> Array<felt252> {
+        fn address_to_domain(self: @ContractState, address: ContractAddress) -> Span<felt252> {
             let mut domain = ArrayTrait::new();
             self._address_to_domain_util(address, ref domain);
             if domain.len() != 0 && self.domain_to_address(domain.span()) == address {
-                domain
+                domain.span()
             } else {
                 let identity = IIdentityDispatcher {
                     contract_address: self.starknetid_contract.read()
@@ -229,9 +229,7 @@ mod Naming {
                 let id_hashed_domain = identity
                     .get_verifier_data(id, 'name', get_contract_address(), 0);
                 let domain = self.unhash_domain(id_hashed_domain);
-                assert(
-                    self.domain_to_address(domain.span()) == address, 'domain not pointing back'
-                );
+                assert(self.domain_to_address(domain) == address, 'domain not pointing back');
                 domain
             }
         }
@@ -369,11 +367,23 @@ mod Naming {
         }
 
 
+        // will override your main id
         fn set_address_to_domain(ref self: ContractState, domain: Span<felt252>) {
             let address = get_caller_address();
             assert(self.domain_to_address(domain) == address, 'domain not pointing back');
             self.emit(Event::AddressToDomainUpdate(AddressToDomainUpdate { address, domain }));
             self.set_address_to_domain_util(address, domain);
+        }
+
+        fn reset_address_to_domain(ref self: ContractState) {
+            let address = get_caller_address();
+            self
+                .emit(
+                    Event::AddressToDomainUpdate(
+                        AddressToDomainUpdate { address, domain: array![].span() }
+                    )
+                );
+            self.set_address_to_domain_util(address, array![0].span());
         }
 
         // ADMIN
@@ -428,7 +438,7 @@ mod Naming {
             return hashed_domain;
         }
 
-        fn unhash_domain(self: @ContractState, domain_hash: felt252) -> Array<felt252> {
+        fn unhash_domain(self: @ContractState, domain_hash: felt252) -> Span<felt252> {
             let mut i = 0;
             let mut domain = ArrayTrait::new();
             loop {
@@ -437,8 +447,9 @@ mod Naming {
                     break;
                 }
                 domain.append(domain_part);
+                i += 1;
             };
-            domain
+            domain.span()
         }
 
         fn assert_purchase_is_possible(
@@ -618,7 +629,7 @@ mod Naming {
                 key: 1,
                 parent_key: 0,
             };
-            self._hash_to_domain.write((hashed_domain, 0), hashed_domain);
+            self._hash_to_domain.write((hashed_domain, 0), domain);
             self._domain_data.write(hashed_domain, data);
             self.emit(Event::DomainMint(DomainMint { domain, owner: id, expiry }));
 

--- a/src/tests/naming/test_usecases.cairo
+++ b/src/tests/naming/test_usecases.cairo
@@ -202,3 +202,68 @@ fn test_non_owner_can_renew_domain() {
     eth.approve(naming.contract_address, price);
     naming.renew(domain_name, 365, ContractAddressZeroable::zero(), 0, 0);
 }
+
+
+#[test]
+#[available_gas(2000000000)]
+fn test_set_address_to_domain() {
+    // setup
+    let (eth, pricing, identity, naming) = deploy();
+    let caller = contract_address_const::<0x123>();
+    set_contract_address(caller);
+    let id1: u128 = 1;
+    let id2: u128 = 2;
+    let first_domain_top: felt252 = 82939898252385817;
+    let second_domain_top: felt252 = 3151716132312299378;
+
+    //we mint the ids
+    identity.mint(id1);
+    identity.mint(id2);
+
+    // buy the domains
+    let (_, price1) = pricing.compute_buy_price(11, 365);
+    eth.approve(naming.contract_address, price1);
+    naming
+        .buy(
+            id1,
+            first_domain_top,
+            365,
+            ContractAddressZeroable::zero(),
+            ContractAddressZeroable::zero(),
+            0,
+            0
+        );
+
+    let (_, price2) = pricing.compute_buy_price(12, 365);
+    eth.approve(naming.contract_address, price2);
+    naming
+        .buy(
+            id2,
+            second_domain_top,
+            365,
+            ContractAddressZeroable::zero(),
+            ContractAddressZeroable::zero(),
+            0,
+            0
+        );
+
+    // let's try the resolving
+    let first_domain = array![first_domain_top].span();
+    assert(naming.domain_to_address(first_domain) == caller, 'wrong domain target');
+
+    // set reverse resolving
+    identity.set_main_id(id1);
+    let expect_domain1 = naming.address_to_domain(caller);
+    assert(expect_domain1 == first_domain, 'wrong rev resolving 1');
+
+    // override reverse resolving
+    let second_domain = array![second_domain_top].span();
+    naming.set_address_to_domain(second_domain);
+    let expect_domain2 = naming.address_to_domain(caller);
+    assert(expect_domain2 == second_domain, 'wrong rev resolving 2');
+
+    // remove override
+    naming.reset_address_to_domain();
+    let expect_domain1 = naming.address_to_domain(caller);
+    assert(expect_domain1 == first_domain, 'wrong rev resolving b');
+}


### PR DESCRIPTION
This pull request adds reverse resolving feature.

By default, your main domain is the one associated to your main id, but you can override this with "set_addr_to_domain". I introduced a new method called "reset_addr_to_domain" to remove this override. I suggest to not allow users to setup this override on the frontend and just keep it as a feature for custom resolver based subdomains (.braavos.stark or .argent.stark for example).

It might be relevant to work on a warning to suggest users with existing reverse resolving to set a main id instead.