### PR TITLE
fix: overriding a subdomain by a root domain

### DIFF
--- a/src/naming/internal.cairo
+++ b/src/naming/internal.cairo
@@ -44,13 +44,15 @@ impl InternalImpl of InternalTrait {
     fn set_address_to_domain_util(
         ref self: Naming::ContractState, address: ContractAddress, mut domain: Span<felt252>
     ) {
-        match domain.pop_back() {
-            Option::Some(domain_part) => {
-                self._address_to_domain.write((address, domain.len()), *domain_part);
-                self.set_address_to_domain_util(address, domain)
-            },
-            Option::None => {}
-        }
+        self._address_to_domain.write((address, domain.len()), 0);
+        loop {
+            match domain.pop_back() {
+                Option::Some(domain_part) => {
+                    self._address_to_domain.write((address, domain.len()), *domain_part);
+                },
+                Option::None => { break; }
+            }
+        };
     }
 
     fn domain_to_resolver(

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -247,7 +247,6 @@ mod Naming {
             }
         }
 
-
         // EXTERNAL
 
         fn buy(


### PR DESCRIPTION
This pull request fixes the main domain issue from https://github.com/starknet-id/app.starknet.id/pull/569

It happened when you had a subdomain set as main domain, it would not get overriden perfectly. E.g. if you had `alpha.bravo.stark` set as main domain and then you write `charlie.stark`, you ended up with `charlie.bravo.stark` which actually didn't exist.