### PR TITLE
feat: add support for ccip reverse resolving

### DIFF
--- a/src/interface/naming.cairo
+++ b/src/interface/naming.cairo
@@ -19,7 +19,7 @@ trait INaming<TContractState> {
         self: @TContractState, domain: Span<felt252>, hint: Span<felt252>
     ) -> ContractAddress;
 
-    fn address_to_domain(self: @TContractState, address: ContractAddress) -> Span<felt252>;
+    fn address_to_domain(self: @TContractState, address: ContractAddress, hint: Span<felt252>) -> Span<felt252>;
 
     // external
     fn buy(
@@ -85,7 +85,7 @@ trait INaming<TContractState> {
 
     fn reset_subdomains(ref self: TContractState, domain: Span<felt252>);
 
-    fn set_address_to_domain(ref self: TContractState, domain: Span<felt252>);
+    fn set_address_to_domain(ref self: TContractState, domain: Span<felt252>, hint: Span<felt252>);
 
     fn clear_legacy_domain_to_address(ref self: TContractState, domain: Span<felt252>);
 

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -232,11 +232,11 @@ mod Naming {
         }
 
         // This function allows to find which domain to use to display an account
-        fn address_to_domain(self: @ContractState, address: ContractAddress) -> Span<felt252> {
+        fn address_to_domain(self: @ContractState, address: ContractAddress, hint: Span<felt252>) -> Span<felt252> {
             let mut domain = ArrayTrait::new();
             self.read_address_to_domain(address, ref domain);
             if domain.len() != 0
-                && self.domain_to_address(domain.span(), array![].span()) == address {
+                && self.domain_to_address(domain.span(), hint) == address {
                 domain.span()
             } else {
                 let identity = IIdentityDispatcher {
@@ -582,10 +582,10 @@ mod Naming {
 
 
         // will override your main id
-        fn set_address_to_domain(ref self: ContractState, domain: Span<felt252>) {
+        fn set_address_to_domain(ref self: ContractState, domain: Span<felt252>, hint: Span<felt252>) {
             let address = get_caller_address();
             assert(
-                self.domain_to_address(domain, array![].span()) == address,
+                self.domain_to_address(domain, hint) == address,
                 'domain not pointing back'
             );
             self.emit(Event::AddressToDomainUpdate(AddressToDomainUpdate { address, domain }));

--- a/src/tests/naming/test_usecases.cairo
+++ b/src/tests/naming/test_usecases.cairo
@@ -257,18 +257,18 @@ fn test_set_address_to_domain() {
 
     // set reverse resolving
     identity.set_main_id(id1);
-    let expect_domain1 = naming.address_to_domain(caller);
+    let expect_domain1 = naming.address_to_domain(caller, array![].span());
     assert(expect_domain1 == first_domain, 'wrong rev resolving 1');
 
     // override reverse resolving
     let second_domain = array![second_domain_top].span();
-    naming.set_address_to_domain(second_domain);
-    let expect_domain2 = naming.address_to_domain(caller);
+    naming.set_address_to_domain(second_domain, array![].span());
+    let expect_domain2 = naming.address_to_domain(caller, array![].span());
     assert(expect_domain2 == second_domain, 'wrong rev resolving 2');
 
     // remove override
     naming.reset_address_to_domain();
-    let expect_domain1 = naming.address_to_domain(caller);
+    let expect_domain1 = naming.address_to_domain(caller, array![].span());
     assert(expect_domain1 == first_domain, 'wrong rev resolving b');
 }
 


### PR DESCRIPTION
Close #26 

This PR adds a hint argument to `address_to_domain` and `set_address_to_domain`

Note : it will require 
- updating the different libs that use `address_to_domain`: starknetid.js, starknet-react and starknet.js
- updating `externalDomainActions` component & `solanaCalls` to set as main domain in the app to add an additional hint parameter & add support for CCIP external domains. 