### PR TITLE
feat: update to cairo 2.6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI Tests
 on: [push, pull_request, pull_request_target]
 
 env:
-  SCARB_VERSION: 2.6.3
+  SCARB_VERSION: 2.6.4
 
 jobs:
   scarb-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI Tests
 on: [push, pull_request, pull_request_target]
 
 env:
-  SCARB_VERSION: 2.3.1
+  SCARB_VERSION: 2.6.3
 
 jobs:
   scarb-tests:

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,11 +5,11 @@ version = "0.1.0"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 
 [dependencies]
-starknet = "2.3.1"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "f3e2a5f0547a429c716f32471b06df729cbdfb9f" }
-storage_read = { git = "https://github.com/starknet-id/storage_read_component.git", rev = "c6c69e15d34abfc39ac51dc21b96724e2e19ff31" }
-identity = { git = "https://github.com/starknet-id/identity.git", rev = "eb37846330b78e1410cf5e3e17a5dcca5652f921" }
-wadray = { git = "https://github.com/lindy-labs/wadray.git", rev = "ea1fa019e7c7c60878ac1e613bc81693524436f5" }
+starknet = "2.6.3"
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", rev = "0697004db74502ce49900edef37331dd03531356" }
+storage_read = { git = "https://github.com/starknet-id/storage_read_component.git", rev = "6440184cc078188d1efeab1283d1698738cde435" }
+identity = { git = "https://github.com/starknet-id/identity.git", rev = "5ae7fafdd20abf4b1e789b83af5db7e23ad39a7c" }
+wadray = { git = "https://github.com/lindy-labs/wadray.git", rev = "9b1f0e21abac6811b09d8a9e861b5d53e6a52d9c" }
 
 [[target.starknet-contract]]
 # Enable Sierra codegen.

--- a/src/naming/asserts.cairo
+++ b/src/naming/asserts.cairo
@@ -10,11 +10,9 @@ use naming::{
     naming::main::{
         Naming,
         Naming::{
-            ContractStateEventEmitter, _hash_to_domain, _hash_to_domainContractMemberStateTrait,
-            _domain_data, _domain_dataContractMemberStateTrait, starknetid_contract,
-            starknetid_contractContractMemberStateTrait, discounts,
-            discountsContractMemberStateTrait, _address_to_domain,
-            _address_to_domainContractMemberStateTrait, _referral_contract,
+            ContractStateEventEmitter, _hash_to_domainContractMemberStateTrait,
+            _domain_dataContractMemberStateTrait, starknetid_contractContractMemberStateTrait,
+            discountsContractMemberStateTrait, _address_to_domainContractMemberStateTrait,
             _referral_contractContractMemberStateTrait,
         }
     },

--- a/src/naming/internal.cairo
+++ b/src/naming/internal.cairo
@@ -8,11 +8,9 @@ use naming::{
     naming::main::{
         Naming,
         Naming::{
-            ContractStateEventEmitter, _hash_to_domain, _hash_to_domainContractMemberStateTrait,
-            _domain_data, _domain_dataContractMemberStateTrait, starknetid_contract,
-            starknetid_contractContractMemberStateTrait, discounts,
-            discountsContractMemberStateTrait, _address_to_domain,
-            _address_to_domainContractMemberStateTrait, _referral_contract,
+            ContractStateEventEmitter, _hash_to_domainContractMemberStateTrait,
+            _domain_dataContractMemberStateTrait, starknetid_contractContractMemberStateTrait,
+            discountsContractMemberStateTrait, _address_to_domainContractMemberStateTrait,
             _referral_contractContractMemberStateTrait,
         }
     }

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -159,7 +159,7 @@ mod Naming {
     #[abi(embed_v0)]
     impl StorageReadComponent = storage_read_component::StorageRead<ContractState>;
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl NamingImpl of INaming<ContractState> {
         // VIEW
 
@@ -233,11 +233,12 @@ mod Naming {
         }
 
         // This function allows to find which domain to use to display an account
-        fn address_to_domain(self: @ContractState, address: ContractAddress, hint: Span<felt252>) -> Span<felt252> {
+        fn address_to_domain(
+            self: @ContractState, address: ContractAddress, hint: Span<felt252>
+        ) -> Span<felt252> {
             let mut domain = ArrayTrait::new();
             self.read_address_to_domain(address, ref domain);
-            if domain.len() != 0
-                && self.domain_to_address(domain.span(), hint) == address {
+            if domain.len() != 0 && self.domain_to_address(domain.span(), hint) == address {
                 domain.span()
             } else {
                 let identity = IIdentityDispatcher {
@@ -583,12 +584,11 @@ mod Naming {
 
 
         // will override your main id
-        fn set_address_to_domain(ref self: ContractState, domain: Span<felt252>, hint: Span<felt252>) {
+        fn set_address_to_domain(
+            ref self: ContractState, domain: Span<felt252>, hint: Span<felt252>
+        ) {
             let address = get_caller_address();
-            assert(
-                self.domain_to_address(domain, hint) == address,
-                'domain not pointing back'
-            );
+            assert(self.domain_to_address(domain, hint) == address, 'domain not pointing back');
             self.emit(Event::AddressToDomainUpdate(AddressToDomainUpdate { address, domain }));
             self.set_address_to_domain_util(address, domain);
         }

--- a/src/naming/utils.cairo
+++ b/src/naming/utils.cairo
@@ -1,7 +1,5 @@
 use core::array::SpanTrait;
-use naming::{
-    naming::main::{Naming, Naming::{_hash_to_domain, _hash_to_domainContractMemberStateTrait}}
-};
+use naming::{naming::main::{Naming, Naming::_hash_to_domainContractMemberStateTrait}};
 use integer::{u256_safe_divmod, u256_as_non_zero};
 use wadray::{Wad, WAD_SCALE};
 

--- a/src/pricing.cairo
+++ b/src/pricing.cairo
@@ -19,7 +19,7 @@ mod Pricing {
         self.erc20.write(erc20_address);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl PricingImpl of IPricing<ContractState> {
         fn compute_buy_price(
             self: @ContractState, domain_len: usize, days: u16

--- a/src/tests/naming/common.cairo
+++ b/src/tests/naming/common.cairo
@@ -23,8 +23,10 @@ use naming::pricing::Pricing;
 
 #[starknet::contract]
 mod ERC20 {
-    use openzeppelin::token::erc20::erc20::ERC20Component::InternalTrait;
-    use openzeppelin::{token::erc20::{ERC20Component, dual20::DualCaseERC20Impl}};
+    use openzeppelin::token::erc20::erc20::ERC20Component::InternalTrait as ERC20InternalTrait;
+    use openzeppelin::{
+        token::erc20::{ERC20Component, dual20::DualCaseERC20Impl, ERC20HooksEmptyImpl}
+    };
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
 
@@ -32,10 +34,11 @@ mod ERC20 {
     impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
     #[abi(embed_v0)]
     impl ERC20CamelOnlyImpl = ERC20Component::ERC20CamelOnlyImpl<ContractState>;
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
 
     #[constructor]
     fn constructor(ref self: ContractState) {
-        self.erc20.initializer('ether', 'ETH');
+        self.erc20.initializer("ether", "ETH");
         let target = starknet::contract_address_const::<0x123>();
         self.erc20._mint(target, 0x100000000000000000000000000000000);
     }
@@ -54,7 +57,6 @@ mod ERC20 {
     }
 }
 
-
 fn deploy() -> (IERC20CamelDispatcher, IPricingDispatcher, IIdentityDispatcher, INamingDispatcher) {
     //erc20
     // 0, 1 = low and high of ETH supply
@@ -64,7 +66,7 @@ fn deploy() -> (IERC20CamelDispatcher, IPricingDispatcher, IIdentityDispatcher, 
     let pricing = utils::deploy(Pricing::TEST_CLASS_HASH, array![eth.into()]);
 
     // identity
-    let identity = utils::deploy(Identity::TEST_CLASS_HASH, array![0x123, 0]);
+    let identity = utils::deploy(Identity::TEST_CLASS_HASH, array![0x123, 0, 0, 0]);
 
     // naming
     let admin = 0x123;

--- a/src/tests/naming/test_abuses.cairo
+++ b/src/tests/naming/test_abuses.cairo
@@ -23,7 +23,7 @@ use super::common::deploy;
 
 #[test]
 #[available_gas(2000000000)]
-#[should_panic(expected: ('u256_sub Overflow', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+#[should_panic(expected: ('ERC20: insufficient balance', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
 fn test_not_enough_eth() {
     // setup
     let (eth, pricing, identity, naming) = deploy();

--- a/src/tests/naming/test_altcoin.cairo
+++ b/src/tests/naming/test_altcoin.cairo
@@ -70,8 +70,8 @@ fn test_buy_domain_with_strk() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
-        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
+        0x6a15a81ccdb2deaa9038e92fd276584fcb7a5849ab959132c4c493f89559059,
+        0x776e83e71aa21170dbacbd74d5e3c518acf073230fcca9900b3a5064da3d234
     );
     naming
         .altcoin_buy(
@@ -124,8 +124,8 @@ fn test_buy_domain_altcoin_quote_expired() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
-        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
+        0x6a15a81ccdb2deaa9038e92fd276584fcb7a5849ab959132c4c493f89559059,
+        0x776e83e71aa21170dbacbd74d5e3c518acf073230fcca9900b3a5064da3d234
     );
 
     // we try buying after the max_validity timestamp
@@ -175,8 +175,8 @@ fn test_buy_domain_altcoin_wrong_quote() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
-        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
+        0x6a15a81ccdb2deaa9038e92fd276584fcb7a5849ab959132c4c493f89559059,
+        0x776e83e71aa21170dbacbd74d5e3c518acf073230fcca9900b3a5064da3d234
     );
     // we try buying with a quote lower than the actual price
     let lower_quote = Wad { val: 1 };
@@ -223,8 +223,8 @@ fn test_renew_domain_with_strk() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
-        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
+        0x6a15a81ccdb2deaa9038e92fd276584fcb7a5849ab959132c4c493f89559059,
+        0x776e83e71aa21170dbacbd74d5e3c518acf073230fcca9900b3a5064da3d234
     );
     naming
         .altcoin_buy(
@@ -258,8 +258,8 @@ fn test_renew_domain_with_strk() {
     // we renew with no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x2e5e08c29c19cbfe55a5ab8386e583d10a72ccda720149f9ca46ac29caa4f70,
-        0x3e9f394c968d48e1b2fc862c6cf5a7970501b375828aacc070e73ad757b18b6
+        0x1ac9f5e9a0239efa0efc9526db0cd650924b8b48b595cd9674a19eab84df962,
+        0x1b78eabc5979b18e44ba4a2350de2597b9403b3777f54220fdf404c08933105
     );
     naming
         .altcoin_renew(
@@ -331,8 +331,8 @@ fn test_subscription_with_strk() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
-        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
+        0x6a15a81ccdb2deaa9038e92fd276584fcb7a5849ab959132c4c493f89559059,
+        0x776e83e71aa21170dbacbd74d5e3c518acf073230fcca9900b3a5064da3d234
     );
     naming
         .altcoin_buy(

--- a/src/tests/naming/test_altcoin.cairo
+++ b/src/tests/naming/test_altcoin.cairo
@@ -46,24 +46,21 @@ fn test_convert_quote_to_eth() {
 #[available_gas(2000000000)]
 fn test_buy_domain_with_strk() {
     // setup
-    let (eth, pricing, identity, naming) = deploy();
+    let (_eth, pricing, identity, naming) = deploy();
     let strk = deploy_stark();
     let caller = contract_address_const::<0x123>();
     set_contract_address(caller);
     let id1: u128 = 1;
     let th0rgal: felt252 = 33133781693;
 
-    naming
-        .set_server_pub_key(
-            1162637274776062843434229637044893256148643831598397603392524411337131005673
-        );
+    naming.set_server_pub_key(0x1ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca);
     set_block_timestamp(500);
 
     //we mint the ids id
     identity.mint(id1);
 
     // we check how much a domain costs
-    let quote = Wad { val: 1591205338160899000000};
+    let quote = Wad { val: 1591205338160899000000 };
     let (_, price_in_eth) = pricing.compute_buy_price(7, 365);
     let price_in_strk: Wad = Wad { val: price_in_eth.low } * quote;
 
@@ -73,8 +70,8 @@ fn test_buy_domain_with_strk() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x45bab8945c7ebe23192a98a496e1f13929ca8fc8edaf810212f0ee00aab9d1c,
-        0x17f03434193b85c7f24354e7de98e4a4bc1e5bd9d26021be3cb26b9c80b282c
+        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
+        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
     );
     naming
         .altcoin_buy(
@@ -103,24 +100,21 @@ fn test_buy_domain_with_strk() {
 #[should_panic(expected: ('quotation expired', 'ENTRYPOINT_FAILED'))]
 fn test_buy_domain_altcoin_quote_expired() {
     // setup
-    let (eth, pricing, identity, naming) = deploy();
+    let (_eth, pricing, identity, naming) = deploy();
     let strk = deploy_stark();
     let caller = contract_address_const::<0x123>();
     set_contract_address(caller);
     let id1: u128 = 1;
     let th0rgal: felt252 = 33133781693;
 
-    naming
-        .set_server_pub_key(
-            1162637274776062843434229637044893256148643831598397603392524411337131005673
-        );
+    naming.set_server_pub_key(0x1ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca);
     set_block_timestamp(500);
 
     //we mint the ids id
     identity.mint(id1);
 
     // we check how much a domain costs
-    let quote = Wad { val: 1591205338160899000000};
+    let quote = Wad { val: 1591205338160899000000 };
     let (_, price_in_eth) = pricing.compute_buy_price(7, 365);
     let price_in_strk: Wad = Wad { val: price_in_eth.low } * quote;
 
@@ -130,8 +124,8 @@ fn test_buy_domain_altcoin_quote_expired() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x45bab8945c7ebe23192a98a496e1f13929ca8fc8edaf810212f0ee00aab9d1c,
-        0x17f03434193b85c7f24354e7de98e4a4bc1e5bd9d26021be3cb26b9c80b282c
+        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
+        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
     );
 
     // we try buying after the max_validity timestamp
@@ -157,24 +151,21 @@ fn test_buy_domain_altcoin_quote_expired() {
 #[should_panic(expected: ('Invalid signature', 'ENTRYPOINT_FAILED'))]
 fn test_buy_domain_altcoin_wrong_quote() {
     // setup
-    let (eth, pricing, identity, naming) = deploy();
+    let (_eth, pricing, identity, naming) = deploy();
     let strk = deploy_stark();
     let caller = contract_address_const::<0x123>();
     set_contract_address(caller);
     let id1: u128 = 1;
     let th0rgal: felt252 = 33133781693;
 
-    naming
-        .set_server_pub_key(
-            1162637274776062843434229637044893256148643831598397603392524411337131005673
-        );
+    naming.set_server_pub_key(0x1ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca);
     set_block_timestamp(500);
 
     //we mint the ids id
     identity.mint(id1);
 
     // we check how much a domain costs
-    let quote = Wad { val: 1591205338160899000000};
+    let quote = Wad { val: 1591205338160899000000 };
     let (_, price_in_eth) = pricing.compute_buy_price(7, 365);
     let price_in_strk: Wad = Wad { val: price_in_eth.low } * quote;
 
@@ -184,11 +175,11 @@ fn test_buy_domain_altcoin_wrong_quote() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x45bab8945c7ebe23192a98a496e1f13929ca8fc8edaf810212f0ee00aab9d1c,
-        0x17f03434193b85c7f24354e7de98e4a4bc1e5bd9d26021be3cb26b9c80b282c
+        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
+        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
     );
     // we try buying with a quote lower than the actual price
-    let lower_quote = Wad { val: 1};
+    let lower_quote = Wad { val: 1 };
     naming
         .altcoin_buy(
             id1,
@@ -209,23 +200,20 @@ fn test_buy_domain_altcoin_wrong_quote() {
 #[available_gas(2000000000)]
 fn test_renew_domain_with_strk() {
     // setup
-    let (eth, pricing, identity, naming) = deploy();
+    let (_eth, pricing, identity, naming) = deploy();
     let strk = deploy_stark();
     let caller = contract_address_const::<0x123>();
     set_contract_address(caller);
     let id1: u128 = 1;
     let th0rgal: felt252 = 33133781693;
 
-    naming
-        .set_server_pub_key(
-            1162637274776062843434229637044893256148643831598397603392524411337131005673
-        );
+    naming.set_server_pub_key(0x1ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca);
 
     //we mint the ids id
     identity.mint(id1);
 
     // we check how much a domain costs
-    let quote = Wad { val: 1591205338160899000000};
+    let quote = Wad { val: 1591205338160899000000 };
     let (_, price_in_eth) = pricing.compute_buy_price(7, 365);
     let price_in_strk: Wad = Wad { val: price_in_eth.low } * quote;
 
@@ -235,8 +223,8 @@ fn test_renew_domain_with_strk() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x45bab8945c7ebe23192a98a496e1f13929ca8fc8edaf810212f0ee00aab9d1c,
-        0x17f03434193b85c7f24354e7de98e4a4bc1e5bd9d26021be3cb26b9c80b282c
+        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
+        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
     );
     naming
         .altcoin_buy(
@@ -260,7 +248,7 @@ fn test_renew_domain_with_strk() {
     );
 
     // we check how much a domain costs to renew
-    let quote = Wad { val: 591205338160899000000};
+    let quote = Wad { val: 591205338160899000000 };
     let (_, price_in_eth) = pricing.compute_buy_price(7, 365);
     let price_in_strk: Wad = Wad { val: price_in_eth.low } * quote;
 
@@ -270,8 +258,8 @@ fn test_renew_domain_with_strk() {
     // we renew with no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x21e23b2bf772d9c088d99103daf233d279e08fd0cce6cd079c1daec5e8e0e99,
-        0x7b362f5fa5907fb805018de4361d42e887f62473d8fd84e0b207e4a9bc99aaa
+        0x2e5e08c29c19cbfe55a5ab8386e583d10a72ccda720149f9ca46ac29caa4f70,
+        0x3e9f394c968d48e1b2fc862c6cf5a7970501b375828aacc070e73ad757b18b6
     );
     naming
         .altcoin_renew(
@@ -321,22 +309,19 @@ fn test_hash_matches() {
 #[available_gas(2000000000)]
 fn test_subscription_with_strk() {
     // setup
-    let (eth, pricing, identity, naming) = deploy();
+    let (_eth, pricing, identity, naming) = deploy();
     let strk = deploy_stark();
     let caller = contract_address_const::<0x123>();
     set_contract_address(caller);
     let id1: u128 = 1;
     let th0rgal: felt252 = 33133781693;
-    naming
-        .set_server_pub_key(
-            1162637274776062843434229637044893256148643831598397603392524411337131005673
-        );
+    naming.set_server_pub_key(0x1ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca);
 
     //we mint the ids id
     identity.mint(id1);
 
     // we check how much a domain costs
-    let quote = Wad { val: 1591205338160899000000};
+    let quote = Wad { val: 1591205338160899000000 };
     let (_, price_in_eth) = pricing.compute_buy_price(7, 365);
     let price_in_strk: Wad = Wad { val: price_in_eth.low } * quote;
 
@@ -346,8 +331,8 @@ fn test_subscription_with_strk() {
     // we buy with no resolver, no sponsor, no discount and empty metadata
     let max_validity = 1000;
     let sig = (
-        0x45bab8945c7ebe23192a98a496e1f13929ca8fc8edaf810212f0ee00aab9d1c,
-        0x17f03434193b85c7f24354e7de98e4a4bc1e5bd9d26021be3cb26b9c80b282c
+        0x380014a735801c32a57b9aca8c31cfdddbcf4bb2823d911342c79cd705a8f98,
+        0x37e305d35b5a3359e99633c22f1e9b4ab14ae9e5d94d8a8618ea3f33473853b
     );
     naming
         .altcoin_buy(
@@ -371,7 +356,7 @@ fn test_subscription_with_strk() {
     );
 
     // we check how much a domain costs to renew
-    let quote = Wad { val: 591205338160899000000};
+    let quote = Wad { val: 591205338160899000000 };
     let (_, price_in_eth) = pricing.compute_buy_price(7, 365);
     let price_in_strk: Wad = Wad { val: price_in_eth.low } * quote;
 
@@ -408,16 +393,13 @@ fn test_subscription_with_strk() {
 #[should_panic(expected: ('Caller not whitelisted', 'ENTRYPOINT_FAILED'))]
 fn test_subscription_not_whitelisted() {
     // setup
-    let (eth, pricing, identity, naming) = deploy();
+    let (_eth, _pricing, identity, naming) = deploy();
     let strk = deploy_stark();
     let caller = contract_address_const::<0x123>();
     set_contract_address(caller);
     let id1: u128 = 1;
     let th0rgal: felt252 = 33133781693;
-    naming
-        .set_server_pub_key(
-            1162637274776062843434229637044893256148643831598397603392524411337131005673
-        );
+    naming.set_server_pub_key(0x1ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca);
 
     //we mint the ids id
     identity.mint(id1);

--- a/src/tests/naming/test_custom_resolver.cairo
+++ b/src/tests/naming/test_custom_resolver.cairo
@@ -32,7 +32,7 @@ mod CustomResolver {
     struct Storage {}
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl AdditionResolveImpl of IResolver<ContractState> {
         fn resolve(
             self: @ContractState, mut domain: Span<felt252>, field: felt252, hint: Span<felt252>

--- a/src/tests/naming/test_usecases.cairo
+++ b/src/tests/naming/test_usecases.cairo
@@ -177,7 +177,7 @@ fn test_non_owner_can_renew_domain() {
     set_contract_address(caller_owner);
 
     let id_owner = 1;
-    let id_not_owner = 2;
+    let _id_not_owner = 2;
     let domain_name: felt252 = 33133781693; // e.g., th0rgal
 
     // Buy for owner

--- a/src/tests/test_pricing.cairo
+++ b/src/tests/test_pricing.cairo
@@ -27,30 +27,30 @@ fn test_buy_price() {
     assert(price == 390000000000000180, 'incorrect price');
 
     // Test with "be" / 2 letters and one year
-    let (erc20, price) = pricing.compute_buy_price(2, 365);
+    let (_erc20, price) = pricing.compute_buy_price(2, 365);
     assert(price == 240000000000000195, 'incorrect price');
 
     // Test with "ben" / 3 letters and one year
-    let (erc20, price) = pricing.compute_buy_price(3, 365);
+    let (_erc20, price) = pricing.compute_buy_price(3, 365);
     assert(price == 73000000000000000, 'incorrect price');
 
     // Test with "benj" / 4 letters and one year
-    let (erc20, price) = pricing.compute_buy_price(4, 365);
+    let (_erc20, price) = pricing.compute_buy_price(4, 365);
     assert(price == 26999999999999990, 'incorrect price');
 
     // Test with "chocolate" / 9 letters and one year
-    let (erc20, price) = pricing.compute_buy_price(9, 365);
+    let (_erc20, price) = pricing.compute_buy_price(9, 365);
     assert(price == 24657534246575 * 365, 'incorrect price');
 
     // Test with "chocolate" / 9 letters and 5 years
-    let (erc20, price) = pricing.compute_buy_price(9, 1825);
+    let (_erc20, price) = pricing.compute_buy_price(9, 1825);
     assert(price == 24657534246575 * 1825, 'incorrect price');
 
     // Test with "chocolate" / 9 letters and 3 years
-    let (erc20, price) = pricing.compute_buy_price(9, 1095);
+    let (_erc20, price) = pricing.compute_buy_price(9, 1095);
     assert(price == 24657534246575 * 1095, 'incorrect price');
 
     // Test with "chocolate" / 9 letters and 20 years
-    let (erc20, price) = pricing.compute_buy_price(9, 7300);
+    let (_erc20, price) = pricing.compute_buy_price(9, 7300);
     assert(price == 24657534246575 * 7300, 'incorrect price');
 }


### PR DESCRIPTION
This pull request updates our naming contract to `Cairo 2.6.3`. To do so it updates the dependencies and some of the syntax. I also had to update the altcoin signatures because this new version of scarb changed the deployed addresses values (instead of being 0,1,2, etc, they are now deterministic values).

closes #30 