### PR TITLE
feat: update pricing of domains

### DIFF
--- a/src/pricing.cairo
+++ b/src/pricing.cairo
@@ -44,7 +44,7 @@ mod Pricing {
     impl InternalImpl of InternalTrait {
         fn get_price_per_day(self: @ContractState, domain_len: usize) -> u128 {
             if domain_len == 1 {
-                return 1068493150684932;
+                return 534246575342466;
             }
 
             if domain_len == 2 {
@@ -52,11 +52,11 @@ mod Pricing {
             }
 
             if domain_len == 3 {
-                return 200000000000000;
+                return 160000000000000;
             }
 
             if domain_len == 4 {
-                return 73972602739726;
+                return 36986301369863;
             }
 
             return 24657534246575;

--- a/src/tests/test_pricing.cairo
+++ b/src/tests/test_pricing.cairo
@@ -24,7 +24,7 @@ fn test_buy_price() {
     // Test with "b" / 1 letter and one year
     let (erc20, price) = pricing.compute_buy_price(1, 365);
     assert(erc20.into() == 0x123, 'wrong erc20 address');
-    assert(price == 390000000000000180, 'incorrect price');
+    assert(price == 195000000000000090, 'incorrect price');
 
     // Test with "be" / 2 letters and one year
     let (_erc20, price) = pricing.compute_buy_price(2, 365);
@@ -32,11 +32,11 @@ fn test_buy_price() {
 
     // Test with "ben" / 3 letters and one year
     let (_erc20, price) = pricing.compute_buy_price(3, 365);
-    assert(price == 73000000000000000, 'incorrect price');
+    assert(price == 58400000000000000, 'incorrect price');
 
     // Test with "benj" / 4 letters and one year
     let (_erc20, price) = pricing.compute_buy_price(4, 365);
-    assert(price == 26999999999999990, 'incorrect price');
+    assert(price == 13499999999999995, 'incorrect price');
 
     // Test with "chocolate" / 9 letters and one year
     let (_erc20, price) = pricing.compute_buy_price(9, 365);


### PR DESCRIPTION
We decided to update domain prices because short domains are not very popular. Here is what it will look like:
5+ letters keep their price (about $25-30)
4 letters will cost 50% less, around $40
3 letters will cost 20% less, around $180
2 letters keep their price
1 letters will cost 50% less, so around $600

This pull request performs this prices update. In ETH prices (approximately):
5+ letters = 0.009 eth/year
4 letters = 0.013 eth/year
3 letters = 0.0584 eth/year
2 letters = 0.24 eth/year
1 letter = 0.195 eth/year

closes #24 