### PR TITLE
fix: 1 letter domain name

### DIFF
--- a/src/pricing.cairo
+++ b/src/pricing.cairo
@@ -44,7 +44,7 @@ mod Pricing {
     impl InternalImpl of InternalTrait {
         fn get_price_per_day(self: @ContractState, domain_len: usize) -> u128 {
             if domain_len == 1 {
-                return 534246575342466;
+                return 801369863013699;
             }
 
             if domain_len == 2 {

--- a/src/tests/test_pricing.cairo
+++ b/src/tests/test_pricing.cairo
@@ -24,7 +24,7 @@ fn test_buy_price() {
     // Test with "b" / 1 letter and one year
     let (erc20, price) = pricing.compute_buy_price(1, 365);
     assert(erc20.into() == 0x123, 'wrong erc20 address');
-    assert(price == 195000000000000090, 'incorrect price');
+    assert(price == 292500000000000135, 'incorrect price');
 
     // Test with "be" / 2 letters and one year
     let (_erc20, price) = pricing.compute_buy_price(2, 365);


### PR DESCRIPTION
The recent pricing update was inconsistent with a 1 letter domain cheaper than 2 letters. This fixes it with a 25% discount instead of 50% on the 1 letter: 0.29 eth/y instead of 0.20 (2 letters is 0.24). We don't change 2 letters because we have many people with automatic renewal enabled on 2 letters domains.