### PR TITLE
fix: user could buy empty domain

### DIFF
--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -284,6 +284,7 @@ mod Naming {
             let (hashed_domain, now, expiry) = self.assert_purchase_is_possible(id, domain, days);
             // we need a u256 to be able to perform safe divisions
             let domain_len = self.get_chars_len(domain.into());
+            assert(domain_len != 0, 'domain can\' be empty');
             // find domain cost
             let (erc20, price) = IPricingDispatcher {
                 contract_address: self._pricing_contract.read()
@@ -311,6 +312,7 @@ mod Naming {
             let (hashed_domain, now, expiry) = self.assert_purchase_is_possible(id, domain, days);
             // we need a u256 to be able to perform safe divisions
             let domain_len = self.get_chars_len(domain.into());
+            assert(domain_len != 0, 'domain can\' be empty');
 
             // check quote timestamp is still valid
             assert(get_block_timestamp() <= max_validity, 'quotation expired');

--- a/src/tests/naming/test_abuses.cairo
+++ b/src/tests/naming/test_abuses.cairo
@@ -298,3 +298,29 @@ fn test_use_reset_subdomains() {
     naming.transfer_domain(subsubdomain2, 4);
 }
 
+#[test]
+#[available_gas(2000000000)]
+#[should_panic(expected: ('domain can\' be empty', 'ENTRYPOINT_FAILED'))]
+fn test_buy_empty_domain() {
+    // setup
+    let (eth, pricing, identity, naming) = deploy();
+    let alpha = contract_address_const::<0x123>();
+
+    // we mint the id
+    set_contract_address(alpha);
+    identity.mint(1);
+
+    set_contract_address(alpha);
+    let empty_domain: felt252 = 0;
+
+    // we check how much a domain costs
+    let (_, price) = pricing.compute_buy_price(0, 365);
+
+    // we allow the naming to take our money
+    eth.approve(naming.contract_address, price);
+
+    // we buy with no resolver, no sponsor, no discount and empty metadata
+    naming
+        .buy(1, empty_domain, 365, ContractAddressZeroable::zero(), ContractAddressZeroable::zero(), 0, 0);
+}
+


### PR DESCRIPTION
Close #46 

For now I checked that `domain_len` is different than 0 in `buy` and `altcoin_buy`. Do you think we should also add this check in the `renew` functions ? 

For the creation of subdomains, we could loop through the domain array received in `transfer_domain` function to check that we don't have any parts that are equal to 0 ? 