### PR TITLE
fix: resolvers returning empty domains causing inverted results

### DIFF
--- a/src/naming/internal.cairo
+++ b/src/naming/internal.cairo
@@ -152,8 +152,9 @@ impl InternalImpl of InternalTrait {
                 .resolve(domain.slice(0, parent_start), field, hint);
             if resolver_res == 0 {
                 let hashed_domain = self.hash_domain(domain);
-                return (0, hashed_domain);
+                return (hashed_domain, 0);
             }
+            // we skip computing the domain_hash if we already have a response
             return (0, resolver_res);
         } else {
             let hashed_domain = self.hash_domain(domain);

--- a/src/naming/main.cairo
+++ b/src/naming/main.cairo
@@ -704,9 +704,7 @@ mod Naming {
             self._admin_address.write(new_admin);
         }
 
-        fn set_expiry(
-            ref self: ContractState, root_domain: felt252, expiry: u64
-        ) {
+        fn set_expiry(ref self: ContractState, root_domain: felt252, expiry: u64) {
             assert(get_caller_address() == self._admin_address.read(), 'you are not admin');
             let hashed_domain = self.hash_domain(array![root_domain].span());
             let domain_data = self._domain_data.read(hashed_domain);


### PR DESCRIPTION
When calling `resolve_util`, computing the domain hash is skipped if we use a custom resolver which directly responds with the output domain. This is not the case if this resolver returns 0 because we need the domain hash.